### PR TITLE
EEF pose tracking service now clears the previous data after saving the results…

### DIFF
--- a/src/lab8/include/lab8/eef_pose_tracker.hpp
+++ b/src/lab8/include/lab8/eef_pose_tracker.hpp
@@ -23,6 +23,14 @@ private:
 
   void timerCallback();
   void plotData();
+
+  void clearData()
+  {
+    x_points_.clear();
+    y_points_.clear();
+    z_points_.clear();
+  }
+
   std::string createTimeStamp();
 
   bool should_track_ {false};

--- a/src/lab8/src/eef_pose_tracker.cpp
+++ b/src/lab8/src/eef_pose_tracker.cpp
@@ -43,6 +43,7 @@ void EEFPoseTracker::requestCallback(
 
     plotData();
     if (poses_csv_.is_open()) {poses_csv_.close();}
+    clearData();
     response->set__success(true);
 
     return;


### PR DESCRIPTION
A quick bug fix which causes the plots for the shapes to stack on top of each other when executing the `draw_shape` node is executed multiple times.

Previously stored data will now be cleared after plotting and saving the CSV when the service receives a `STOP` request.